### PR TITLE
Corrige HMR dos estilos

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,3 +18,4 @@ export default {
 };
 </script>
 
+<style lang="scss" src="./assets/sass/_styles.scss"></style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import './assets/sass/_styles.scss';
 
 import router from './router';
 import App from './App.vue';


### PR DESCRIPTION
Agora os estilos são carregados via o atributo src da tag style do component App.vue, ao invés de serem importados no main.js. Desta maneira o HMR para estilo funciona corretamente.
![SCSS HMR](https://user-images.githubusercontent.com/7695608/51434495-e5321b00-1c48-11e9-821a-86c62e1f191e.gif)

Esta é a forma recomendada de importar estilos standalone globais:
http://vuejs-templates.github.io/webpack/pre-processors.html#standalone-css-files