### PR TITLE
Corrige layout responsivo da homepage

### DIFF
--- a/src/assets/sass/_card.scss
+++ b/src/assets/sass/_card.scss
@@ -10,12 +10,15 @@
   
   > .icone {
     color: #FFFFFF;
+    height: 90px;
+    margin-bottom: 20px;
   }
 
-  & label {
-    font-size: 23px;
+  & .label {
+    font-size: 1.2em;
     font-weight: bold;
     color: #FFFFFF;
-    font-family: 'Montserrat Bold'
+    font-family: 'Montserrat Bold';
+    text-transform: uppercase;
   }
 }

--- a/src/assets/sass/_card.scss
+++ b/src/assets/sass/_card.scss
@@ -4,9 +4,7 @@
   align-items: center;
   flex-direction: column;
   border-radius: 15px;
-  margin: 10px;
   padding: 20px;
-  width: 200px;
   
   > .icone {
     color: #FFFFFF;

--- a/src/assets/sass/_container.scss
+++ b/src/assets/sass/_container.scss
@@ -1,9 +1,8 @@
 .container {
-  // margin: 100px;
-  padding: 100px;
 
   .logo {
     max-width: 350px;
+    height: auto;
     margin-bottom: 50px;   
   }
   
@@ -11,5 +10,13 @@
     font-size: 18px;
     font-family: 'Montserrat Medium';
     color: #6A6A6A;
+  }
+
+  .cards-title {
+    font-size: 1.1em;
+    font-weight: bold;
+    color: #989898;
+    font-family: 'Montserrat Bold';
+    text-transform: uppercase;
   }
 }

--- a/src/assets/sass/_grid.scss
+++ b/src/assets/sass/_grid.scss
@@ -1,0 +1,36 @@
+.card-column {
+  @include tablet {
+    flex: 0 0 230px;
+  }
+}
+
+.is-centered-tablet-only {
+  @include tablet {
+    justify-content: center;
+  }
+  @include desktop {
+    justify-content: flex-start;
+  }
+}
+
+.column.cards-container-column {
+  @include widescreen {
+    flex: none;
+    width: 480px;
+  }
+}
+
+.main {
+  padding: 20px;
+  max-width: 460px;
+  margin: auto;
+  @include tablet {
+    padding: 0;
+    max-width: 560px;
+  }
+  @include desktop {
+    padding: 0;
+    max-width: none;
+    margin: none;
+  }
+}

--- a/src/assets/sass/_styles.scss
+++ b/src/assets/sass/_styles.scss
@@ -1,6 +1,7 @@
 @import '~bulma/bulma';
 @import '~normalize.css/normalize.css';
 @import './typography';
+@import './grid';
 @import './home';
 @import './_card';
 @import './_container';

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,11 +1,9 @@
 <template>
   <div class="card-valorize" v-bind:style = "{'background-color': bgColor}">
-    <figure class="icone" v-if="icon">
-      <img :src="require(`@/assets/icons/${icon}.svg`)">
-    </figure>
-    <label :for="title">
+      <img class="icone" v-if="icon" :src="require(`@/assets/icons/${icon}.svg`)">
+    <span class="label">
       {{ title }}
-    </label>
+    </span>
   </div>
 </template>
 

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -2,61 +2,80 @@
 <div>
   <section>
     <div class="container">
-      <div class="columns">
-        <div class="column is-4">
-          <figure class="logo">
-            <img src="../assets/images/logo-horizontal.svg" alt="Valorize Vidas">
-          </figure>
-        </div>
-        <div class="column is-4">
-          <div class="mensagem">
-            <p>Pode ficar tranquilo que podemos te ajudar. Entre em contato com a gente
-               da forma como preferir</p>
+      <div class="main">
+        <div class="columns is-multiline is-centered-tablet-only">
+          <div class="column is-full-tablet is-4-desktop">
+            <figure class="logo">
+              <img src="../assets/images/logo-horizontal.svg" alt="Valorize Vidas">
+            </figure>
+          </div>
+          <div class="column is-full-tablet is-4-desktop">
+            <div class="mensagem">
+              <p>Pode ficar tranquilo que podemos te ajudar. Entre em contato com a gente da forma como preferir</p>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="columns">
-        <div class="column">
-          <Card
-          :title="'Chat'"
-          :icon="'comments-regular'"
-          :bgColor="'#F38C18'"
-          />
-        </div>
-        <div class="column">
-          <Card
-          :title="'Ligue 188'"
-          :icon="'mobile-alt-solid'"
-          :bgColor="'#F38C18'"
-          />
-        </div>
-        <div class="column">
-          <Card
-          :title="'Contribuir'"
-          :icon="'hand-holding-usd-solid'"
-          :bgColor="'#E8AE28'"
-          />
-        </div>
-        <div class="column">
-          <Card
-          :title="'Voluntariar'"
-          :icon="'hand-holding-heart-solid'"
-          :bgColor="'#F7C248'"
-          />
-        </div>
-      </div>
-      <div class="columns">
-        <div class="column is-3">
-          <Card
-          :title="'Email'"
-          :bgColor="'#F38C18'"
-          />
-        </div>
-        <div class="column">
-          <Card
-          :title="'Endereços'"
-          :bgColor="'#F38C18'"
-          />
+        <div class="columns is-multiline">
+          <div class="column is-full-tablet is-half-desktop cards-container-column">
+            <div class="columns is-variable is-4 is-centered-tablet-only">
+              <div class="column is-half-desktop">
+                <span class="cards-title">Precisa de ajuda?</span>
+              </div>
+            </div>
+            <div class="columns is-variable is-4">
+              <div class="column card-column">
+                <Card
+                :title="'Chat'"
+                :icon="'comments-regular'"
+                :bgColor="'#F38C18'"
+                />
+                </div>
+              <div class="column card-column">
+                <Card
+                :title="'Ligue 188'"
+                :icon="'mobile-alt-solid'"
+                :bgColor="'#F38C18'"
+                />
+              </div>
+            </div>
+            <div class="columns is-variable is-4">
+              <div class="column card-column">
+                <Card
+                :title="'Email'"
+                :bgColor="'#F38C18'"
+                />
+              </div>
+              <div class="column card-column">
+                <Card
+                :title="'Endereços'"
+                :bgColor="'#F38C18'"
+                />
+              </div>
+            </div>
+          </div>
+          <div class="column is-full-tablet is-half-desktop cards-container-column">
+            <div class="columns is-variable is-4 is-centered-tablet-only">
+              <div class="column is-half-desktop">
+                <span class="cards-title">Quer ajudar?</span>
+              </div>
+            </div>
+            <div class="columns is-variable is-4">
+              <div class="column card-column">
+                <Card
+                :title="'Contribuir'"
+                :icon="'hand-holding-usd-solid'"
+                :bgColor="'#E8AE28'"
+                />
+                </div>
+              <div class="column card-column">
+                <Card
+                :title="'Voluntariar'"
+                :icon="'hand-holding-heart-solid'"
+                :bgColor="'#F7C248'"
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Atualmente o layout responsivo não funciona nos tamanhos tablet e desktop (conteúdo flui para fora da página), e possui algumas falhas no tamanho mobile (opções de contato separadas).

Este PR resolve os issues #33 e #51: Corrige os problemas acima, utiliza colunas de largura fixa para manter os botões e seus ícones com o mesmo tamanho, mantém os cards de endereço e email juntos ao chat e telefone em todos os tamanhos.