### PR TITLE
Adicina Yarn como dependencia

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ O que é necessário para rodar o projeto?
 
 ```
 Node.Js 8.x
+Yarn
 ```
 
 ### Instalando


### PR DESCRIPTION
Como vocês aconselham o uso do yarn ao invés do NPM, é necessário adicionar o Yarn como dependencia, pois ele não vem instalado junto do NodeJS.