### PR TITLE
Simplifica alinhamentos

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,15 @@
 <template>
   <div id="app">
     <Navbar />
-    <section class="columns">
-      <div class="column"></div>
+    <section class="columns is-centered">
       <div class="column is-three-fifths">
         <router-view />
       </div>
-      <div class="column"></div>
     </section>
-    <div class="columns">
-      <div class="column"></div>
-    </div>
-    <div class="columns">
-      <div class="column"></div>
+    <div class="columns is-centered">
       <div class="column is-three-fifths">
         <Footer />
       </div>
-      <div class="column"></div>
     </div>
   </div>
 </template>

--- a/src/components/FormContact.vue
+++ b/src/components/FormContact.vue
@@ -1,7 +1,6 @@
 <template>
-  <div class="columns form">
-    <div class="column is-3"></div>
-    <div class="column">
+  <div class="columns is-centered form">
+    <div class="column is-half">
       <iframe
         class="google-forms"
         :src="consts.contact"
@@ -11,7 +10,6 @@
         >Carregando…</iframe
       >
     </div>
-    <div class="column is-3"></div>
   </div>
 </template>
 <script>

--- a/src/components/FormContactVolunteer.vue
+++ b/src/components/FormContactVolunteer.vue
@@ -1,7 +1,6 @@
 <template>
-  <div class="columns form">
-    <div class="column is-3"></div>
-    <div class="column">
+  <div class="columns is-centered form">
+    <div class="column is-half">
       <iframe
         class="google-forms"
         :src="consts.volunteer"
@@ -11,7 +10,6 @@
         >Carregando…</iframe
       >
     </div>
-    <div class="column is-3"></div>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Simplifica a centralização de colunas utilizando a classe .is-centered ao invés de colunas adicionais vazias. (https://bulma.io/documentation/columns/options/#centering-columns)

Closes #87 